### PR TITLE
fix: resolve arithmetic overflow in capture.rs

### DIFF
--- a/programs/mpl-hybrid/src/instructions/capture.rs
+++ b/programs/mpl-hybrid/src/instructions/capture.rs
@@ -136,8 +136,7 @@ pub fn handler_capture_v1(ctx: Context<CaptureV1Ctx>) -> Result<()> {
     if Path::RerollMetadata.check(escrow.path) {
         let clock = Clock::get()?;
         // seed for the random number is a combination of the slot_hash - timestamp
-        let seed = u64::from_le_bytes(*most_recent).saturating_sub(clock.unix_timestamp as u64)
-            * escrow.count;
+        let seed = u64::from_le_bytes(*most_recent).saturating_sub(clock.unix_timestamp as u64);
         // remainder is the random number between the min and max
         let remainder = seed
             .checked_rem(escrow.max - escrow.min)


### PR DESCRIPTION
Hi Metaplex Team,

I discovered a potential arithmetic overflow issue in the `capture.rs` file. This issue can occur in the following code line:

https://github.com/metaplex-foundation/mpl-hybrid/blob/6376558f9bfed0bcf29e1ac5b3d5a48f35975422/programs/mpl-hybrid/src/instructions/capture.rs#L139-L140

Here's a detailed reproduction of the issue:

- code

```rust
    let timestamp = clock.unix_timestamp as u64;
    msg!("timestamp: {}", timestamp);
    let recent_bytes = u64::from_le_bytes(*most_recent);
    msg!("recent_bytes: {}", recent_bytes);
    let subtracted_value=recent_bytes.saturating_sub(timestamp);
    msg!("subtracted_value: {}", subtracted_value);
    msg!("escrow.count: {}", escrow.count);
    let seed = subtracted_value * escrow.count;
    msg!("seed: {}", seed);
```
- tx

https://explorer.solana.com/tx/2cgKF1g5mCjgxkfPYRvi26Qqw4z9zRmx3ybA5WUfywGYZZzG4UWXz6VufNPdzFvfrZDyFgUWfKmFG43Ke1bdWNm?cluster=devnet

- logs

![logs](https://github.com/user-attachments/assets/3ba4f63c-f017-40c4-8801-bfd398bb7a8b)

To resolve this issue, I have removed the multiplication by escrow.count as it can lead to overflow. This fix ensures the arithmetic operation remains within safe bounds, preventing potential crashes.

Regarding the Bounty Program, I noticed there is no specific mention of a [reward for bugs](https://www.metaplex.com/bounty-program) related to mpl-hybrid. If there is a bounty available for this fix, please send the reward to the following Solana address: `72SebYpPzemzf4h7g52dgCc4awKgmHnoRmn8PLpP8MaK`.

Thank you for your attention to this matter.
