### PR TITLE
Initialize Solana CLI config before solana-verify PDA upload

### DIFF
--- a/.github/workflows/deploy-program.yml
+++ b/.github/workflows/deploy-program.yml
@@ -210,6 +210,16 @@ jobs:
             --max-sign-attempts 100 \
             --use-rpc
 
+      # solana-verify 0.4.15 unconditionally loads ~/.config/solana/cli/config.yml
+      # during PDA upload (Ellipsis-Labs/solana-verifiable-build process_otter_verify_ixs),
+      # so initialize a CLI config even though --keypair and --url are passed explicitly.
+      - name: Initialize Solana CLI config for solana-verify
+        if: github.event.inputs.dry_run == 'false' && inputs.cluster == 'mainnet-beta'
+        run: |
+          solana config set \
+            --url "${RPC}" \
+            --keypair "${GITHUB_WORKSPACE}/deployer-key.json"
+
       - name: Upload verified-build PDA
         if: github.event.inputs.dry_run == 'false' && inputs.cluster == 'mainnet-beta'
         run: |

--- a/.github/workflows/verify-program.yml
+++ b/.github/workflows/verify-program.yml
@@ -84,6 +84,15 @@ jobs:
           printf '%s' "$HYBRID_ID" > ./program-id.json
           printf '%s' "$HYBRID_DEPLOYER_KEY" > ./deployer-key.json
 
+      # solana-verify 0.4.15 unconditionally loads ~/.config/solana/cli/config.yml
+      # during PDA upload (Ellipsis-Labs/solana-verifiable-build process_otter_verify_ixs),
+      # so initialize a CLI config even though --keypair and --url are passed explicitly.
+      - name: Initialize Solana CLI config for solana-verify
+        run: |
+          solana config set \
+            --url "${RPC}" \
+            --keypair "${GITHUB_WORKSPACE}/deployer-key.json"
+
       - name: Upload verified-build PDA
         run: |
           PROGRAM_ID="$(solana-keygen pubkey ./program-id.json)"


### PR DESCRIPTION
solana-verify 0.4.15 unconditionally loads ~/.config/solana/cli/config.yml during the verified-build PDA upload, even when --keypair and --url are passed explicitly. GitHub Actions runners have no Solana CLI config by default, so the upload step fails with "No such file or directory (os error 2)" right after the on-chain hash check succeeds. Initialize the CLI config in both deploy-program and verify-program workflows before invoking solana-verify.